### PR TITLE
Update ArticleForm expiry_date optional

### DIFF
--- a/src/pages/ArticleForm.tsx
+++ b/src/pages/ArticleForm.tsx
@@ -14,7 +14,7 @@ type FormData = {
   agency: string;
   quantity: number;
   unit: string;
-  expiry_date: string;
+  expiry_date?: string;
   unit_price: number;
   description: string;
 };
@@ -137,6 +137,7 @@ export default function ArticleForm() {
 
       const articleData = {
         ...data,
+        expiry_date: data.expiry_date || null,
         user_id: user.id,
         image_url: imageUrl,
         total_price: data.quantity * (data.unit_price || 0),

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -325,8 +325,13 @@ const Dashboard: React.FC = () => {
           .from('articles')
           .delete()
           .eq('id', id);
-          
+
         if (error) throw error;
+
+        setArticles(prev => prev.filter(article => article.id !== id));
+        setFilteredArticles(prev => prev.filter(article => article.id !== id));
+        setOpenActionMenuId(null);
+
         toast.success('Article supprimé avec succès');
       } catch (error) {
         console.error('Error deleting article:', error);
@@ -724,6 +729,13 @@ const Dashboard: React.FC = () => {
                     <div className="flex justify-between items-center text-sm text-gray-600 mb-2">
                       <span>Fournisseur: {article.supplier}</span>
                       <span className="font-medium">{article.quantity} {article.unit}</span>
+                    </div>
+
+                    <div className="flex items-center text-sm text-gray-500 mb-2">
+                      <Calendar className="h-4 w-4 mr-1" />
+                      <span>
+                        Ajouté le {format(new Date(article.created_at), 'dd MMMM yyyy', { locale: fr })}
+                      </span>
                     </div>
                     
                     {/* Description - affichée uniquement si elle existe */}


### PR DESCRIPTION
## Summary
- allow expiry date field to be optional
- send `null` to the database if expiry date is not provided
- show article creation date on dashboard

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a70a6bcc8320b412d2819cf2c872