### PR TITLE
Move quantity display next to article name

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -711,11 +711,16 @@ const Dashboard: React.FC = () => {
                   </div>
                   
                   <div className="p-4">
-                    <Link to={`/articles/${article.id}`} className="block">
-                      <h3 className="text-lg font-semibold text-gray-800 mb-2 hover:text-orange-600 transition-colors">
-                        {article.name}
-                      </h3>
-                    </Link>
+                    <div className="flex justify-between items-baseline">
+                      <Link to={`/articles/${article.id}`} className="block">
+                        <h3 className="text-lg font-semibold text-gray-800 mb-2 hover:text-orange-600 transition-colors">
+                          {article.name}
+                        </h3>
+                      </Link>
+                      <span className="text-sm font-medium text-gray-600">
+                        {article.quantity} {article.unit}
+                      </span>
+                    </div>
                     
                     <div className="flex flex-wrap gap-2 mb-3">
                       <span className="px-2 py-1 bg-orange-100 text-orange-800 text-xs rounded-full">
@@ -726,9 +731,8 @@ const Dashboard: React.FC = () => {
                       </span>
                     </div>
                     
-                    <div className="flex justify-between items-center text-sm text-gray-600 mb-2">
-                      <span>Fournisseur: {article.supplier}</span>
-                      <span className="font-medium">{article.quantity} {article.unit}</span>
+                    <div className="text-sm text-gray-600 mb-2">
+                      Fournisseur: {article.supplier}
                     </div>
 
                     <div className="flex items-center text-sm text-gray-500 mb-2">


### PR DESCRIPTION
## Summary
- update the dashboard article card to show quantity beside the article name

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840c39a38e4832095da6d2755ae9f66