### PR TITLE
Improve product card display

### DIFF
--- a/src/pages/ArticleDetails.tsx
+++ b/src/pages/ArticleDetails.tsx
@@ -75,7 +75,7 @@ const ArticleDetails: React.FC = () => {
     
     if (isBefore(expiryDate, today)) {
       return 'expired';
-    } else if (isBefore(expiryDate, addDays(today, 30))) {
+    } else if (isBefore(expiryDate, addDays(today, 15))) {
       return 'expiring-soon';
     } else {
       return 'valid';
@@ -148,6 +148,11 @@ const ArticleDetails: React.FC = () => {
                 >
                   <ZoomIn className="h-4 w-4" />
                 </button>
+                {expiryStatus === 'expired' && (
+                  <div className="absolute top-2 right-2 translate-x-12 bg-red-600 text-white px-2 py-1 rounded-md text-xs font-bold">
+                    Périmé
+                  </div>
+                )}
               </div>
             ) : (
               <div className="w-full h-full min-h-64 flex items-center justify-center">
@@ -159,14 +164,16 @@ const ArticleDetails: React.FC = () => {
           <div className="md:w-2/3 p-6">
             <div className="flex justify-between items-start mb-4">
               <div>
-                <h1 className="text-2xl font-bold text-gray-800">{article.name}</h1>
-                <div className="flex flex-wrap gap-2 mt-2">
+                <div className="flex flex-wrap gap-2 mb-2">
                   <span className="px-3 py-1 bg-orange-100 text-orange-800 text-sm rounded-full">
                     {article.category}
                   </span>
                   <span className="px-3 py-1 bg-blue-100 text-blue-800 text-sm rounded-full">
                     {article.agency}
                   </span>
+                </div>
+                <h1 className="text-2xl font-bold text-gray-800">{article.name}</h1>
+                <div className="flex flex-wrap gap-2 mt-2">
                   {expiryStatus === 'expired' && (
                     <span className="px-3 py-1 bg-red-100 text-red-800 text-sm rounded-full flex items-center">
                       <AlertCircle className="h-4 w-4 mr-1" />
@@ -251,20 +258,24 @@ const ArticleDetails: React.FC = () => {
                 {article.expiry_date && (
                   <div>
                     <h3 className="text-sm font-medium text-gray-500">Date de péremption</h3>
-                    <p className={`text-lg font-semibold flex items-center ${
-                      expiryStatus === 'expired' ? 'text-red-600' : 
-                      expiryStatus === 'expiring-soon' ? 'text-orange-600' : 
-                      'text-gray-800'
-                    }`}>
-                      <Calendar className={`h-5 w-5 mr-1 ${
-                        expiryStatus === 'expired' ? 'text-red-500' : 
-                        expiryStatus === 'expiring-soon' ? 'text-orange-500' : 
-                        'text-gray-500'
-                      }`} />
+                    <p
+                      className={`text-lg flex items-center ${
+                        expiryStatus === 'expired' || expiryStatus === 'expiring-soon'
+                          ? 'font-bold text-red-600'
+                          : 'font-semibold text-gray-800'
+                      }`}
+                    >
+                      <Calendar
+                        className={`h-5 w-5 mr-1 ${
+                          expiryStatus === 'expired' || expiryStatus === 'expiring-soon'
+                            ? 'text-red-600'
+                            : 'text-gray-500'
+                        }`}
+                      />
                       {format(new Date(article.expiry_date), 'dd MMMM yyyy', { locale: fr })}
                     </p>
-                  </div>
-                )}
+                 </div>
+               )}
               </div>
             </div>
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -179,13 +179,13 @@ const Dashboard: React.FC = () => {
   // Vérifier si un article est expiré ou expire bientôt
   const getExpiryStatus = (article: Article): 'expired' | 'expiring-soon' | 'valid' | null => {
     if (!article.expiry_date) return null;
-    
+
     const today = new Date();
     const expiryDate = new Date(article.expiry_date);
-    
+
     if (isBefore(expiryDate, today)) {
       return 'expired';
-    } else if (isBefore(expiryDate, addDays(today, 30))) {
+    } else if (isBefore(expiryDate, addDays(today, 15))) {
       return 'expiring-soon';
     } else {
       return 'valid';
@@ -528,7 +528,7 @@ const Dashboard: React.FC = () => {
                 >
                   <option value="">Tous les statuts</option>
                   <option value="expired">Périmés</option>
-                  <option value="expiring-soon">Expire bientôt (30 jours)</option>
+                  <option value="expiring-soon">Expire bientôt (15 jours)</option>
                   <option value="valid">Valides</option>
                 </select>
               </div>
@@ -696,8 +696,7 @@ const Dashboard: React.FC = () => {
                     </div>
                     
                     {expiryStatus === 'expired' && (
-                      <div className="absolute bottom-2 left-2 bg-red-100 text-red-800 px-2 py-1 rounded-md text-xs font-medium flex items-center">
-                        <AlertCircle className="h-3 w-3 mr-1" />
+                      <div className="absolute top-2 right-2 bg-red-600 text-white px-2 py-1 rounded-md text-xs font-bold">
                         Périmé
                       </div>
                     )}
@@ -711,18 +710,7 @@ const Dashboard: React.FC = () => {
                   </div>
                   
                   <div className="p-4">
-                    <div className="flex justify-between items-baseline">
-                      <Link to={`/articles/${article.id}`} className="block">
-                        <h3 className="text-lg font-semibold text-gray-800 mb-2 hover:text-orange-600 transition-colors">
-                          {article.name}
-                        </h3>
-                      </Link>
-                      <span className="text-sm font-medium text-gray-600">
-                        {article.quantity} {article.unit}
-                      </span>
-                    </div>
-                    
-                    <div className="flex flex-wrap gap-2 mb-3">
+                    <div className="flex flex-wrap gap-2 mb-2">
                       <span className="px-2 py-1 bg-orange-100 text-orange-800 text-xs rounded-full">
                         {article.category}
                       </span>
@@ -730,42 +718,47 @@ const Dashboard: React.FC = () => {
                         {article.agency}
                       </span>
                     </div>
-                    
-                    <div className="text-sm text-gray-600 mb-2">
-                      Fournisseur: {article.supplier}
-                    </div>
-
-                    <div className="flex items-center text-sm text-gray-500 mb-2">
-                      <Calendar className="h-4 w-4 mr-1" />
-                      <span>
-                        Ajouté le {format(new Date(article.created_at), 'dd MMMM yyyy', { locale: fr })}
+                    <div className="flex justify-between items-baseline">
+                      <Link to={`/articles/${article.id}`} className="block">
+                        <h2 className="text-lg font-bold text-gray-800 mb-2 hover:text-orange-600 transition-colors">
+                          {article.name}
+                        </h2>
+                      </Link>
+                      <span className="text-sm font-medium text-gray-600">
+                        {article.quantity} {article.unit}
                       </span>
                     </div>
                     
-                    {/* Description - affichée uniquement si elle existe */}
-                    {hasDescription && (
-                      <div className="mt-2 mb-3">
-                        <div className="flex items-start text-sm text-gray-600">
+                    <div className="bg-gray-50 rounded-md p-2 text-sm text-gray-600 space-y-1 mb-3">
+                      <div>Fournisseur: {article.supplier}</div>
+                      <div className="flex items-center">
+                        <Calendar className="h-4 w-4 mr-1" />
+                        <span>
+                          Ajouté le {format(new Date(article.created_at), 'dd MMMM yyyy', { locale: fr })}
+                        </span>
+                      </div>
+                      {hasDescription && (
+                        <div className="flex items-start">
                           <FileText className="h-4 w-4 mr-1 mt-0.5 text-orange-500 flex-shrink-0" />
                           <div>
-                            <p className={isDescriptionExpanded ? "" : "line-clamp-2"}>
+                            <p className={isDescriptionExpanded ? '' : 'line-clamp-2'}>
                               {article.description}
                             </p>
                             {article.description && article.description.length > 100 && (
-                              <button 
+                              <button
                                 onClick={(e) => {
                                   e.preventDefault();
                                   toggleDescriptionExpand(article.id);
                                 }}
                                 className="text-orange-600 hover:text-orange-800 text-xs mt-1 font-medium"
                               >
-                                {isDescriptionExpanded ? "Voir moins" : "Voir plus"}
+                                {isDescriptionExpanded ? 'Voir moins' : 'Voir plus'}
                               </button>
                             )}
                           </div>
                         </div>
-                      </div>
-                    )}
+                      )}
+                    </div>
                     
                     <div className="mt-3 space-y-1">
                       {article.unit_price !== null && (
@@ -788,12 +781,12 @@ const Dashboard: React.FC = () => {
                     </div>
                     
                     {article.expiry_date && (
-                      <div className="flex items-center text-sm mt-2" 
-                        style={{ 
-                          color: expiryStatus === 'expired' ? '#e53e3e' : 
-                                 expiryStatus === 'expiring-soon' ? '#dd6b20' : 
-                                 '#718096' 
-                        }}
+                      <div
+                        className={`flex items-center text-sm mt-2 ${
+                          expiryStatus === 'expired' || expiryStatus === 'expiring-soon'
+                            ? 'text-red-600 font-bold'
+                            : 'text-gray-600'
+                        }`}
                       >
                         <Calendar className="h-4 w-4 mr-1" />
                         <span>


### PR DESCRIPTION
## Summary
- tweak expiry threshold to 15 days
- add expired badge on article card images
- group secondary info in card footer
- highlight product name and expiration date
- show agency and category tags above article names

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840c7c6bd1883208abe0a222303a4d2